### PR TITLE
Add link to bitcoin++ ecash talk

### DIFF
--- a/src/pages/resources/learn.mdx
+++ b/src/pages/resources/learn.mdx
@@ -9,6 +9,7 @@ export const description = 'A collection of educational resources.'
 - Blinding custodians with Cashu, Adopting Bitcoin Conference 2022 [Video](https://www.youtube.com/watch?v=UNjVc-WYdgE&t=105s)
 - PlebDevs Theory: Cashu Gets Nutty, 2024 [Video](https://www.youtube.com/watch?v=zhJZnxaLLU4&t=791s)
 - Nostr The Medium Of The Ecash Economy w/Calle, nostr.world 2024 [Video](https://www.youtube.com/watch?v=OHqxp-Hrx9k)
+- The Second Renaissance of ecash w/Calle, bitcoin++ ecash edition 2024 [Video](https://www.youtube.com/watch?v=DZjqTsgO8To)
 
 #### Preso Links
 - Ecash in the wild, HCPP/BTC++ 2023 [PDF](https://docs.cashu.space/pdf/cashu-01-2023.pdf)


### PR DESCRIPTION
This PR adds a link to a 2024 intro talk under the Learn More section.