### PR TITLE
Replace Discord link with new Matrix space link

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -86,4 +86,4 @@ Cashu libraries are available for various programming languages. Click [here](/l
 
 ## Join Cashu R&D {{ id: 'join' }}
 
-We have a [Discord server](https://discord.gg/9AFCsNSY8C) and a [Telegram channel](https://t.me/CashuBTC) focussed on Cashu R&D. If you're developer, please join us!
+We have a [Matrix space](https://matrix.to/#/#dev:matrix.cashu.space) and a [Telegram channel](https://t.me/CashuBTC) focussed on Cashu R&D. If you're developer, please join us!


### PR DESCRIPTION
This PR replaces the Matrix link with the new Matrix link.