### PR TITLE
docs: clarify BDHKE protocol notation and steps

### DIFF
--- a/src/pages/protocol.mdx
+++ b/src/pages/protocol.mdx
@@ -28,6 +28,7 @@ The Blind Diffie-Hellmann Key Exchange (BDHKE) is the basic cryptographic scheme
 
 - `x` random string (secret message), corresponds to point `Y` on curve
 - `r` private key (blinding factor)
+- `R` public key (blinding factor)
 - `T` blinded message
 - `Z` proof (unblinded signature)
 
@@ -35,8 +36,8 @@ The Blind Diffie-Hellmann Key Exchange (BDHKE) is the basic cryptographic scheme
 
 - Mint `Bob` publishes public key `K = kG`
 - `Alice` picks secret `x` and computes `Y = hash_to_curve(x)`
-- `Alice` sends to `Bob`: `B_ = Y + rG` with `r` being a random blindind factor (**blinding**)
-- `Bob` sends back to `Alice` blinded key: `C_ = kB_` (these two steps are the DH key exchange) (**signing**)
-- `Alice` can calculate the unblinded key as `C_ - rK = kY + krG - krG = kY = C` (**unblinding**)
-- Alice can take the pair `(x, C)` as a token and can send it to `Carol`.
-- `Carol` can send `(x, C)` to `Bob` who then checks that `k*hash_to_curve(x) == C` (**verification**), and if so treats it as a valid spend of a token, adding `x` to the list of spent secrets.
+- `Alice` sends to `Bob`: `T = Y + rG = Y + R` with `r` being a random blinding factor (**blinding**)
+- `Bob` sends back to `Alice` blinded key: `Q = Tk = Yk + Rk` (these two steps are the DH key exchange) (**signing**)
+- `Alice` can calculate the unblinded key as `Z = Q - rK = Yk + Rk - rK = Yk + rGk - rkG = Yk` (**unblinding**)
+- Alice can take the pair `(x, Z)` as a token and can send it to `Carol`.
+- `Carol` can send `(x, Z)` to `Bob` who then checks that `k*hash_to_curve(x) == Z` (**verification**), and if so treats it as a valid spend of a token, adding `x` to the list of spent secrets.


### PR DESCRIPTION
- Replaced ambiguous variable names `(B_, C_)` with clearer names `(T, Q, Z)`.
- Made blinding and unblinding steps more explicit using `R = rG` and `K = kG`.
- Added intermediate equations for better clarity in DHKE.
- Fixed typo (`s/blindind/blinding`).
- Improved readability and consistency of cryptographic notation.

---

I was walking through the protocol here at Casa21 and found the current doc a bit hard to follow. I had to rename a couple of things while explaining it on the whiteboard, so I'm bringing those clarifications back into the documentation here. Hopefully this makes the flow and the roles of each variable a bit clearer.